### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Promocodes/Form/CampaignPromocodesGenerate.php
+++ b/CRM/Promocodes/Form/CampaignPromocodesGenerate.php
@@ -79,9 +79,9 @@ class CRM_Promocodes_Form_CampaignPromocodesGenerate extends CRM_Core_Form
 
         // Store defaults as setting.
         $values = [
-            'campaign_id' => CRM_Utils_Array::value('campaign_id', $all_values),
-            'code_type' => CRM_Utils_Array::value('code_type', $all_values),
-            'financial_type_id' => CRM_Utils_Array::value('financial_type_id', $all_values),
+            'campaign_id' => $all_values['campaign_id'] ?? NULL,
+            'code_type' => $all_values['code_type'] ?? NULL,
+            'financial_type_id' => $all_values['financial_type_id'] ?? NULL,
         ];
         Civi::settings()->set('de.systopia.promocodes.campaign', $values);
 

--- a/CRM/Promocodes/Form/Task/Generate.php
+++ b/CRM/Promocodes/Form/Task/Generate.php
@@ -132,9 +132,9 @@ class CRM_Promocodes_Form_Task_Generate extends CRM_Contact_Form_Task
 
         // store defaults
         $values = array(
-            'campaign_id'       => CRM_Utils_Array::value('campaign_id', $all_values),
-            'code_type'         => CRM_Utils_Array::value('code_type', $all_values),
-            'financial_type_id' => CRM_Utils_Array::value('financial_type_id', $all_values),
+            'campaign_id'       => $all_values['campaign_id'] ?? NULL,
+            'code_type'         => $all_values['code_type'] ?? NULL,
+            'financial_type_id' => $all_values['financial_type_id'] ?? NULL,
         );
         $indices = range(1,self::CUSTOM_FIELD_COUNT);
         foreach ($indices as $i) {

--- a/CRM/Promocodes/Form/Task/GenerateMembership.php
+++ b/CRM/Promocodes/Form/Task/GenerateMembership.php
@@ -132,9 +132,9 @@ class CRM_Promocodes_Form_Task_GenerateMembership extends CRM_Member_Form_Task
 
         // store defaults
         $values = array(
-            'campaign_id'       => CRM_Utils_Array::value('campaign_id', $all_values),
-            'financial_type_id' => CRM_Utils_Array::value('financial_type_id', $all_values),
-            'code_type'         => CRM_Utils_Array::value('code_type', $all_values),
+            'campaign_id'       => $all_values['campaign_id'] ?? NULL,
+            'financial_type_id' => $all_values['financial_type_id'] ?? NULL,
+            'code_type'         => $all_values['code_type'] ?? NULL,
         );
         $indices = range(1,self::CUSTOM_FIELD_COUNT);
         foreach ($indices as $i) {


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.