### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Promocodes/Form/CampaignPromocodesGenerate.php
+++ b/CRM/Promocodes/Form/CampaignPromocodesGenerate.php
@@ -71,7 +71,7 @@ class CRM_Promocodes_Form_CampaignPromocodesGenerate extends CRM_Core_Form
     }
 
     /**
-     * @throws CiviCRM_API3_Exception
+     * @throws CRM_Core_Exception
      */
     public function postProcess()
     {

--- a/CRM/Promocodes/Form/Task/Generate.php
+++ b/CRM/Promocodes/Form/Task/Generate.php
@@ -123,7 +123,7 @@ class CRM_Promocodes_Form_Task_Generate extends CRM_Contact_Form_Task
      *  - store submitted settings as new defaults
      *  - generate CSV
      *
-     * @throws CiviCRM_API3_Exception
+     * @throws CRM_Core_Exception
      */
     public function postProcess()
     {

--- a/CRM/Promocodes/Form/Task/GenerateMembership.php
+++ b/CRM/Promocodes/Form/Task/GenerateMembership.php
@@ -123,7 +123,7 @@ class CRM_Promocodes_Form_Task_GenerateMembership extends CRM_Member_Form_Task
      *  - store submitted settings as new defaults
      *  - generate CSV
      *
-     * @throws CiviCRM_API3_Exception
+     * @throws CRM_Core_Exception
      */
     public function postProcess()
     {

--- a/CRM/Promocodes/Utils.php
+++ b/CRM/Promocodes/Utils.php
@@ -137,7 +137,7 @@ class CRM_Promocodes_Utils {
      * @return array
      *    SELECT SQL snippet, JOIN SQL snippet
      *
-     * @throws CiviCRM_API3_Exception
+     * @throws CRM_Core_Exception
      *   should anything go wrong looking up the field metadata
      */
     public static function buildCustomFieldSnippets($custom_field_specs, $alias_mapping = []) {

--- a/api/v3/Promocode/Validate.php
+++ b/api/v3/Promocode/Validate.php
@@ -21,7 +21,7 @@ function _civicrm_api3_promocode_Validate_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_promocode_Validate($params) {
   $data = array(


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.